### PR TITLE
SEG FAULT FIX

### DIFF
--- a/cdcl-vsads/solver.cpp
+++ b/cdcl-vsads/solver.cpp
@@ -163,7 +163,7 @@ struct Statistics
   uint64_t simplifications;
   mpz_class n_assignments_partial;
 
-  Statistics() { memset(this, 0, sizeof *this); }
+  Statistics() = default;
 
   double average(double a, double b) { return b ? a / b : 0; }
   double percent(double a, double b) { return average(100 * a, b); }


### PR DESCRIPTION
Hi,
While running the tool on benchmarks on , there is a Segmentation Fault (core dumped) error.
Please see below example:

./solver ./../test/basic/0002.cnf
c TabularAllSAT+: CB-CDCL AllSAT Solver without blocking clauses
c Version 1.0 0
c Compiled with 'g++ -Wall -O3 -DNDEBUG'
c
c reading from './../test/basic/0002.cnf'
c parsed header 'p cnf 1 1'
c parsed single clause
c
c caught signal 11
c
c        0.00    1.55%  search
c -----------------------------------
c        0.00  100.00%  total
c
c n-partial-assignments 0
c analyzed:                        0          0.00 % conflicts
c chronological:                   0          0.00 % analyzed
c conflicts:                       0          0.00 per second
c decisions:                       0          0.00 per conflict
c learned-clause-size:          0.00
c minimized-literals:           0.00 %
c propagations:                    1        862.07 per second
c recycled-clauses:                0          0.00 % added
c reductions:                      0          0.00 interval
c rephased:                        0          0.00 interval
c restarts:                        0          0.00 interval
c simplifications:                 0          0.00 % reductions
c units:                           0          0.00 % conflicts
c
c process-time:                               0.00 seconds
c maximum-resident-set-size:                  2.60 MB
c
c raising signal 11
Segmentation fault (core dumped)



Proposed Solution:
https://github.com/giuspek/tabularAllSAT/blob/920f6c2c1ab59d1b48ca06610f2994bea8595918/cdcl-vsads/solver.cpp#L166

On this line: 
change
Statistics() { memset(this, 0, sizeof *this); }
to 
Statistics() = default;

This fixes the issue.

System tested on Ubuntu 20.04.6 LTS